### PR TITLE
Lexicographical interpolation to approximate size

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2672,9 +2672,20 @@ uint64_t BlockBasedTable::ApproximateSize(const Slice& start, const Slice& end,
   }
 
   assert(end_offset >= start_offset);
+  uint64_t offset_diff = end_offset - start_offset;
+
+  if (offset_diff == 0) {
+    // If the offset difference is 0, it means the start and end keys lie within the same block.
+    // In this case, we overestimate and return the block size
+    if (index_iter->Valid()) {
+      BlockHandle handle = index_iter->value().handle;
+      offset_diff = handle.size();
+    }
+  }
+
   // Pro-rate file metadata (incl filters) size-proportionally across data
   // blocks.
-  double size_ratio = static_cast<double>(end_offset - start_offset) /
+  double size_ratio = static_cast<double>(offset_diff) /
                       static_cast<double>(data_size);
   return static_cast<uint64_t>(size_ratio *
                                static_cast<double>(rep_->file_size));

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2698,9 +2698,19 @@ uint64_t BlockBasedTable::ApproximateDataOffsetWithinBlock(
 
   // Use lexicographical interpolation to estimate the position
   const Comparator* ucmp = rep_->internal_comparator.user_comparator();
+  Slice user_key;
+  Slice first_user_key;
+  Slice last_user_key;
+
+  if (rep_->index_key_includes_seq) {
+    first_user_key = ExtractUserKey(first_key_in_block);
+    last_user_key = ExtractUserKey(last_key_in_block);
+  } else {
+    first_user_key = first_key_in_block;
+    last_user_key = last_key_in_block;
+  }
+
   Slice user_key = ExtractUserKey(key);
-  Slice first_user_key = ExtractUserKey(first_key_in_block);
-  Slice last_user_key = ExtractUserKey(last_key_in_block);
 
   double ratio = CalculateKeyPositionRatio(user_key, first_user_key, last_user_key, ucmp);
   return static_cast<uint64_t>((1.0 - ratio) * handle.size());

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2698,7 +2698,6 @@ uint64_t BlockBasedTable::ApproximateDataOffsetWithinBlock(
 
   // Use lexicographical interpolation to estimate the position
   const Comparator* ucmp = rep_->internal_comparator.user_comparator();
-  Slice user_key;
   Slice first_user_key;
   Slice last_user_key;
 

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2623,53 +2623,87 @@ uint64_t BlockBasedTable::ApproximateDataOffsetWithinBlock(
   Slice first_user_key = ExtractUserKey(first_key_in_block);
   Slice last_user_key = ExtractUserKey(last_key_in_block);
 
-  // If key is <= first_key_in_block, it's at the beginning of the block
-  if (ucmp->Compare(user_key, first_user_key) <= 0) {
-    return handle.size();  // Return full size so when subtracted, we get the start of the block
+  double ratio = CalculateKeyPositionRatio(user_key, first_user_key, last_user_key, ucmp);
+  return static_cast<uint64_t>((1.0 - ratio) * handle.size());
+}
+
+// Calculate the position ratio of target_key between first_key and last_key
+// Returns a value between 0.0 (closer to first_key) and 1.0 (closer to last_key)
+double CalculateKeyPositionRatio(const Slice& target_key,
+                                const Slice& first_key,
+                                const Slice& last_key,
+                                const Comparator* comparator) {
+  // Boundary checks
+  if (comparator->Compare(target_key, first_key) <= 0) {
+    return 0.0;
+  }
+  if (comparator->Compare(target_key, last_key) >= 0) {
+    return 1.0;
   }
 
-  // If key is >= last_key_in_block, it's at the end of the block
-  if (ucmp->Compare(user_key, last_user_key) >= 0) {
-    return 0;  // Return 0 so when subtracted, we still get the block's offset
+  // Find the first position where first_key and last_key differ
+  size_t diff_pos = 0;
+  size_t min_len = std::min(first_key.size(), last_key.size());
+  while (diff_pos < min_len && first_key[diff_pos] == last_key[diff_pos]) {
+    diff_pos++;
   }
 
-  // Find the common prefix length between first and last keys
-  size_t first_last_diff = first_user_key.difference_offset(last_user_key);
-
-  // If first and last key are the same (or one is prefix of the other), assume middle position
-  if (first_last_diff >= first_user_key.size() ||
-      first_last_diff >= last_user_key.size()) {
-    return handle.size() / 2;
-  }
-
-  // Find difference offsets between target key and endpoints
-  size_t first_target_diff = first_user_key.difference_offset(user_key);
-  size_t target_last_diff = user_key.difference_offset(last_user_key);
-
-  // If the difference offsets don't align with our expectations, default to middle
-  if (first_target_diff < first_last_diff && target_last_diff < first_last_diff) {
-    // Estimate the position by using the first differing byte
-    uint8_t first_byte = static_cast<uint8_t>(first_user_key[first_last_diff]);
-    uint8_t target_byte = static_cast<uint8_t>(user_key[first_last_diff]);
-    uint8_t last_byte = static_cast<uint8_t>(last_user_key[first_last_diff]);
-
-    // Ensure we have a valid range to interpolate over
-    if (last_byte > first_byte) {
-      // Calculate the ratio based on the byte values
-      double ratio = static_cast<double>(target_byte - first_byte) /
-                    static_cast<double>(last_byte - first_byte);
-
-      // Bound the ratio between 0 and 1
-      ratio = std::max(0.0, std::min(1.0, ratio));
-
-      // Estimate the offset within the block - inverted so the beginning of the block is handle.size()
-      // and the end of the block is 0
-      return static_cast<uint64_t>((1.0 - ratio) * handle.size());
+  // If keys are identical up to the length of the shorter one,
+  // use length-based interpolation
+  if (diff_pos == min_len) {
+    if (first_key.size() == last_key.size()) {
+      // Keys are identical, shouldn't happen given boundary checks
+      return 0.5;
     }
+
+    // One key is a prefix of the other
+    double length_ratio = static_cast<double>(target_key.size() - first_key.size()) /
+                         static_cast<double>(last_key.size() - first_key.size());
+    return std::max(0.0, std::min(1.0, length_ratio));
   }
 
-  // Fallback to middle position if interpolation can't be applied
-  return handle.size() / 2;
+  // Use multi-byte interpolation for better accuracy
+  // Convert up to 8 bytes starting from diff_pos to a numeric value
+  auto extractNumericValue = [](const Slice& key, size_t start_pos) -> uint64_t {
+    uint64_t value = 0;
+    size_t bytes_to_read = std::min(size_t(8), key.size() - start_pos);
+
+    for (size_t i = 0; i < bytes_to_read; i++) {
+      value = (value << 8) | static_cast<uint8_t>(key[start_pos + i]);
+    }
+
+    // Pad with zeros if we read fewer than 8 bytes
+    value <<= (8 - bytes_to_read) * 8;
+    return value;
+  };
+
+  // Extract numeric values from the differing position
+  uint64_t first_value = extractNumericValue(first_key, diff_pos);
+  uint64_t last_value = extractNumericValue(last_key, diff_pos);
+  uint64_t target_value = extractNumericValue(target_key, diff_pos);
+
+  // Handle edge case where first and last values are the same
+  if (first_value == last_value) {
+    // This shouldn't happen given our diff_pos calculation, but just in case
+    return 0.5;
+  }
+
+  // Calculate interpolation ratio using full 64-bit precision
+  double ratio;
+  if (first_value < last_value) {
+    ratio = static_cast<double>(target_value - first_value) /
+            static_cast<double>(last_value - first_value);
+  } else {
+    // Handle reverse order
+    ratio = static_cast<double>(first_value - target_value) /
+            static_cast<double>(first_value - last_value);
+  }
+
+  // Apply smoothing for very small or very large ratios to avoid edge effects
+  if (ratio < 0.001) ratio = ratio * 0.5;
+  else if (ratio > 0.999) ratio = 0.999 + (ratio - 0.999) * 0.5;
+
+  return std::max(0.0, std::min(1.0, ratio));
 }
 
 uint64_t BlockBasedTable::GetApproximateDataSize() {

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2214,12 +2214,12 @@ Status BlockBasedTable::Get(const ReadOptions& read_options, const Slice& key,
             /*referenced_key=*/"", referenced_data_size,
             lookup_data_block_context.num_keys_in_block,
             does_referenced_key_exist);
-        // TODO: Should handle status here?
-        block_cache_tracer_
-            ->WriteBlockAccess(access_record,
-                               lookup_data_block_context.block_key,
-                               rep_->cf_name_for_tracing(), referenced_key)
-            .PermitUncheckedError();
+          // TODO: Should handle status here?
+          block_cache_tracer_
+              ->WriteBlockAccess(access_record,
+                                 lookup_data_block_context.block_key,
+                                 rep_->cf_name_for_tracing(), referenced_key)
+              .PermitUncheckedError();
       }
 
       if (done) {
@@ -2574,6 +2574,104 @@ uint64_t BlockBasedTable::ApproximateDataOffsetOf(
   }
 }
 
+uint64_t BlockBasedTable::ApproximateDataOffsetWithinBlock(
+    InternalIteratorBase<IndexValue>* index_iter,
+    const Slice& key) const {
+  if (!index_iter->Valid()) {
+    return 0;
+  }
+
+  // Get the block handle for the data block
+  BlockHandle handle = index_iter->value().handle;
+
+  // If we have a first_internal_key in the index value, we can use it for better interpolation
+  Slice first_key_in_block;
+  Slice last_key_in_block = index_iter->key();
+
+  if (rep_->index_has_first_key) {
+    first_key_in_block = index_iter->value().first_internal_key;
+  } else {
+    // If first key is not available in the index, we can try to infer it
+    // by checking the previous entry in the index
+
+    // Save our current position and key
+    Slice current_position_key = last_key_in_block;
+
+    // Try to move to previous entry
+    index_iter->Prev();
+    if (index_iter->Valid()) {
+      // Got a previous entry, use its key as our first key approximation
+      first_key_in_block = index_iter->key();
+
+      // Restore original position
+      index_iter->Seek(current_position_key);
+      // Verify we restored correctly
+      assert(index_iter->Valid());
+      assert(index_iter->key().compare(current_position_key) == 0);
+    } else {
+      // No previous entry (we're at the first block)
+      // Restore position and use midpoint fallback
+      index_iter->Seek(current_position_key);
+      assert(index_iter->Valid());
+      return handle.size() / 2;
+    }
+  }
+
+  // Use lexicographical interpolation to estimate the position
+  const Comparator* ucmp = rep_->internal_comparator.user_comparator();
+  Slice user_key = ExtractUserKey(key);
+  Slice first_user_key = ExtractUserKey(first_key_in_block);
+  Slice last_user_key = ExtractUserKey(last_key_in_block);
+
+  // If key is <= first_key_in_block, it's at the beginning of the block
+  if (ucmp->Compare(user_key, first_user_key) <= 0) {
+    return handle.size();  // Return full size so when subtracted, we get the start of the block
+  }
+
+  // If key is >= last_key_in_block, it's at the end of the block
+  if (ucmp->Compare(user_key, last_user_key) >= 0) {
+    return 0;  // Return 0 so when subtracted, we still get the block's offset
+  }
+
+  // Find the common prefix length between first and last keys
+  size_t first_last_diff = first_user_key.difference_offset(last_user_key);
+
+  // If first and last key are the same (or one is prefix of the other), assume middle position
+  if (first_last_diff >= first_user_key.size() ||
+      first_last_diff >= last_user_key.size()) {
+    return handle.size() / 2;
+  }
+
+  // Find difference offsets between target key and endpoints
+  size_t first_target_diff = first_user_key.difference_offset(user_key);
+  size_t target_last_diff = user_key.difference_offset(last_user_key);
+
+  // If the difference offsets don't align with our expectations, default to middle
+  if (first_target_diff < first_last_diff && target_last_diff < first_last_diff) {
+    // Estimate the position by using the first differing byte
+    uint8_t first_byte = static_cast<uint8_t>(first_user_key[first_last_diff]);
+    uint8_t target_byte = static_cast<uint8_t>(user_key[first_last_diff]);
+    uint8_t last_byte = static_cast<uint8_t>(last_user_key[first_last_diff]);
+
+    // Ensure we have a valid range to interpolate over
+    if (last_byte > first_byte) {
+      // Calculate the ratio based on the byte values
+      double ratio = static_cast<double>(target_byte - first_byte) /
+                    static_cast<double>(last_byte - first_byte);
+
+      // Bound the ratio between 0 and 1
+      ratio = std::max(0.0, std::min(1.0, ratio));
+
+      // Estimate the offset within the block - inverted so the beginning of the block is handle.size()
+      // and the end of the block is 0
+      return static_cast<uint64_t>((1.0 - ratio) * handle.size());
+    }
+  }
+
+  // Fallback to middle position if interpolation can't be applied
+  return handle.size() / 2;
+}
+
 uint64_t BlockBasedTable::GetApproximateDataSize() {
   // Should be in table properties unless super old version
   if (rep_->table_properties) {
@@ -2605,7 +2703,6 @@ uint64_t BlockBasedTable::ApproximateOffsetOf(const Slice& key,
   if (index_iter != &iiter_on_stack) {
     iiter_unique_ptr.reset(index_iter);
   }
-
   index_iter->Seek(key);
   uint64_t offset;
   if (index_iter->status().ok()) {
@@ -2655,6 +2752,8 @@ uint64_t BlockBasedTable::ApproximateSize(const Slice& start, const Slice& end,
   uint64_t start_offset;
   if (index_iter->status().ok()) {
     start_offset = ApproximateDataOffsetOf(*index_iter, data_size);
+    uint64_t start_blk_offset = ApproximateDataOffsetWithinBlock(index_iter, start);
+    start_offset -= start_blk_offset;
   } else {
     // Assume file is involved from the start. This likely skews the estimate
     // but is consistent with the above error handling.
@@ -2665,6 +2764,8 @@ uint64_t BlockBasedTable::ApproximateSize(const Slice& start, const Slice& end,
   uint64_t end_offset;
   if (index_iter->status().ok()) {
     end_offset = ApproximateDataOffsetOf(*index_iter, data_size);
+    uint64_t end_blk_offset = ApproximateDataOffsetWithinBlock(index_iter, end);
+    end_offset -= end_blk_offset;
   } else {
     // Assume file is involved until the end. This likely skews the estimate
     // but is consistent with the above error handling.
@@ -2672,20 +2773,10 @@ uint64_t BlockBasedTable::ApproximateSize(const Slice& start, const Slice& end,
   }
 
   assert(end_offset >= start_offset);
-  uint64_t offset_diff = end_offset - start_offset;
-
-  if (offset_diff == 0) {
-    // If the offset difference is 0, it means the start and end keys lie within the same block.
-    // In this case, we overestimate and return the block size
-    if (index_iter->Valid()) {
-      BlockHandle handle = index_iter->value().handle;
-      offset_diff = handle.size();
-    }
-  }
 
   // Pro-rate file metadata (incl filters) size-proportionally across data
   // blocks.
-  double size_ratio = static_cast<double>(offset_diff) /
+  double size_ratio = static_cast<double>(end_offset - start_offset) /
                       static_cast<double>(data_size);
   return static_cast<uint64_t>(size_ratio *
                                static_cast<double>(rep_->file_size));

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -2574,59 +2574,6 @@ uint64_t BlockBasedTable::ApproximateDataOffsetOf(
   }
 }
 
-uint64_t BlockBasedTable::ApproximateDataOffsetWithinBlock(
-    InternalIteratorBase<IndexValue>* index_iter,
-    const Slice& key) const {
-  if (!index_iter->Valid()) {
-    return 0;
-  }
-
-  // Get the block handle for the data block
-  BlockHandle handle = index_iter->value().handle;
-
-  // If we have a first_internal_key in the index value, we can use it for better interpolation
-  Slice first_key_in_block;
-  Slice last_key_in_block = index_iter->key();
-
-  if (rep_->index_has_first_key) {
-    first_key_in_block = index_iter->value().first_internal_key;
-  } else {
-    // If first key is not available in the index, we can try to infer it
-    // by checking the previous entry in the index
-
-    // Save our current position and key
-    Slice current_position_key = last_key_in_block;
-
-    // Try to move to previous entry
-    index_iter->Prev();
-    if (index_iter->Valid()) {
-      // Got a previous entry, use its key as our first key approximation
-      first_key_in_block = index_iter->key();
-
-      // Restore original position
-      index_iter->Seek(current_position_key);
-      // Verify we restored correctly
-      assert(index_iter->Valid());
-      assert(index_iter->key().compare(current_position_key) == 0);
-    } else {
-      // No previous entry (we're at the first block)
-      // Restore position and use midpoint fallback
-      index_iter->Seek(current_position_key);
-      assert(index_iter->Valid());
-      return handle.size() / 2;
-    }
-  }
-
-  // Use lexicographical interpolation to estimate the position
-  const Comparator* ucmp = rep_->internal_comparator.user_comparator();
-  Slice user_key = ExtractUserKey(key);
-  Slice first_user_key = ExtractUserKey(first_key_in_block);
-  Slice last_user_key = ExtractUserKey(last_key_in_block);
-
-  double ratio = CalculateKeyPositionRatio(user_key, first_user_key, last_user_key, ucmp);
-  return static_cast<uint64_t>((1.0 - ratio) * handle.size());
-}
-
 // Calculate the position ratio of target_key between first_key and last_key
 // Returns a value between 0.0 (closer to first_key) and 1.0 (closer to last_key)
 double CalculateKeyPositionRatio(const Slice& target_key,
@@ -2704,6 +2651,59 @@ double CalculateKeyPositionRatio(const Slice& target_key,
   else if (ratio > 0.999) ratio = 0.999 + (ratio - 0.999) * 0.5;
 
   return std::max(0.0, std::min(1.0, ratio));
+}
+
+uint64_t BlockBasedTable::ApproximateDataOffsetWithinBlock(
+    InternalIteratorBase<IndexValue>* index_iter,
+    const Slice& key) const {
+  if (!index_iter->Valid()) {
+    return 0;
+  }
+
+  // Get the block handle for the data block
+  BlockHandle handle = index_iter->value().handle;
+
+  // If we have a first_internal_key in the index value, we can use it for better interpolation
+  Slice first_key_in_block;
+  Slice last_key_in_block = index_iter->key();
+
+  if (rep_->index_has_first_key) {
+    first_key_in_block = index_iter->value().first_internal_key;
+  } else {
+    // If first key is not available in the index, we can try to infer it
+    // by checking the previous entry in the index
+
+    // Save our current position and key
+    Slice current_position_key = last_key_in_block;
+
+    // Try to move to previous entry
+    index_iter->Prev();
+    if (index_iter->Valid()) {
+      // Got a previous entry, use its key as our first key approximation
+      first_key_in_block = index_iter->key();
+
+      // Restore original position
+      index_iter->Seek(current_position_key);
+      // Verify we restored correctly
+      assert(index_iter->Valid());
+      assert(index_iter->key().compare(current_position_key) == 0);
+    } else {
+      // No previous entry (we're at the first block)
+      // Restore position and use midpoint fallback
+      index_iter->Seek(current_position_key);
+      assert(index_iter->Valid());
+      return handle.size() / 2;
+    }
+  }
+
+  // Use lexicographical interpolation to estimate the position
+  const Comparator* ucmp = rep_->internal_comparator.user_comparator();
+  Slice user_key = ExtractUserKey(key);
+  Slice first_user_key = ExtractUserKey(first_key_in_block);
+  Slice last_user_key = ExtractUserKey(last_key_in_block);
+
+  double ratio = CalculateKeyPositionRatio(user_key, first_user_key, last_user_key, ucmp);
+  return static_cast<uint64_t>((1.0 - ratio) * handle.size());
 }
 
 uint64_t BlockBasedTable::GetApproximateDataSize() {

--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -489,6 +489,11 @@ class BlockBasedTable : public TableReader {
       const InternalIteratorBase<IndexValue>& index_iter,
       uint64_t data_size) const;
 
+  // Given a start key, returns the approximate data offset by doing a lexi interpolation
+  uint64_t ApproximateDataOffsetWithinBlock(
+      InternalIteratorBase<IndexValue>* index_iter,
+      const Slice& key) const;
+
   // Helper functions for DumpTable()
   Status DumpIndexBlock(std::ostream& out_stream);
   Status DumpDataBlocks(std::ostream& out_stream);


### PR DESCRIPTION
This is an alternative fix to #1 that uses lexicographical interpolation to approximate size more accurately